### PR TITLE
Removed duplication by extracting the variant function as an argument

### DIFF
--- a/tim-cooke_clojure/alphabet-cipher/README.md
+++ b/tim-cooke_clojure/alphabet-cipher/README.md
@@ -2,6 +2,37 @@
 
 Making fun use of the Arrow Macro (a.k.a Thread Macro).
 
-## Future improvements
+## Solution 1
 
-There's some serious code duplication going on that can be addressed.
+There's a lot of duplication here. The only variant is the map function of either + or -.
+
+    (defn encode [msg key]
+      (->> msg
+        (map #(+ (- (int %2) (int \a)) (- (int %1) (int \a))) (flatten (cycle key)))
+        (map #(mod % 26))
+        (map #(char (+ % (int \a))))
+        (apply str)))
+
+    (defn decode [msg key]
+      (->> msg
+        (map #(- (- (int %2) (int \a)) (- (int %1) (int \a))) (flatten (cycle key)))
+        (map #(mod % 26))
+        (map #(char (+ % (int \a))))
+        (apply str)))
+
+## Solution 2
+
+Duplication removed by replacing the single variant function with a function argument.
+
+    (defn cipher [msg key direction]
+      (->> msg
+        (map #(direction (- (int %2) (int \a)) (- (int %1) (int \a))) (flatten (cycle key)))
+        (map #(mod % 26))
+        (map #(char (+ % (int \a))))
+        (apply str)))
+
+    (defn encode [msg key]
+      (cipher msg key +))
+
+    (defn decode [msg key]
+      (cipher msg key -))

--- a/tim-cooke_clojure/alphabet-cipher/src/alphabet_cipher/core.clj
+++ b/tim-cooke_clojure/alphabet-cipher/src/alphabet_cipher/core.clj
@@ -1,16 +1,15 @@
 (ns alphabet-cipher.core
   (:gen-class))
 
-(defn encode [msg key]
+(defn cipher [msg key direction]
   (->> msg
-        (map #(+ (- (int %2) (int \a)) (- (int %1) (int \a))) (flatten (cycle key)))
-        (map #(mod % 26))
-        (map #(char (+ % (int \a))))
-        (apply str)))
-
-(defn decode [msg key]
-  (->> msg
-      (map #(- (- (int %2) (int \a)) (- (int %1) (int \a))) (flatten (cycle key)))
+      (map #(direction (- (int %2) (int \a)) (- (int %1) (int \a))) (flatten (cycle key)))
       (map #(mod % 26))
       (map #(char (+ % (int \a))))
       (apply str)))
+
+(defn encode [msg key]
+  (cipher msg key +))
+
+(defn decode [msg key]
+  (cipher msg key -))


### PR DESCRIPTION
An example of where passing functions as first class constructs is pretty useful.
